### PR TITLE
fix(mesh): remove duplicate SSE data: prefix in /api/mesh/events

### DIFF
--- a/app/src/main/java/io/casehub/claudony/server/MeshResource.java
+++ b/app/src/main/java/io/casehub/claudony/server/MeshResource.java
@@ -107,15 +107,15 @@ public class MeshResource {
                     return Uni.combine().all().unis(channels, instances, feed)
                             .combinedWith((ch, inst, f) -> {
                                 try {
-                                    return "data: " + mapper.writeValueAsString(Map.of(
+                                    return mapper.writeValueAsString(Map.of(
                                             "channels", ch,
                                             "instances", inst,
-                                            "feed", f)) + "\n\n";
+                                            "feed", f));
                                 } catch (Exception e) {
-                                    return "data: {}\n\n";
+                                    return "{}";
                                 }
                             })
-                            .onFailure().recoverWithItem("data: {}\n\n");
+                            .onFailure().recoverWithItem("{}");
                 });
     }
 


### PR DESCRIPTION
## Problem

GET /api/mesh/events produces double-framed SSE data:
```
data: data: {...}\n\n
```

RESTEasy Reactive's SSE encoder already adds the `data: ` prefix.
The `events()` method was manually pre-pending it, causing the double-frame.

## Fix

Remove the manual `data: ` prefix and `\n\n` suffix in the `events()` method.
Return raw JSON — RESTEasy Reactive handles SSE framing.

Also fixes the error fallback `"data: {}\n\n"` → `"{}"`.

## Testing

The existing test `MeshResourceTest` covers the `/events` endpoint.
Manual verification: `curl -N http://localhost:8080/api/mesh/events`
should show `data: {...}` not `data: data: {...}`.

## Refs

Fixes casehubio/claudony#132